### PR TITLE
fix(plugin): update view option type definition

### DIFF
--- a/src/app/view/grid-view/grid-view-options.ts
+++ b/src/app/view/grid-view/grid-view-options.ts
@@ -1,4 +1,5 @@
-import type { ViewOption } from 'obsidian'
+// Obsidian v1.10.3 seemingly replaced ViewOption with BasesAllOptions
+import type { BasesAllOptions } from 'obsidian'
 import {
     BATCH_FILTER_MODE_OPTIONS,
     DEFAULT_BATCH_FILTER_MODE,
@@ -10,7 +11,7 @@ import {
 /**
  * Get view options for Grid View configuration
  */
-export function getGridViewOptions(): ViewOption[] {
+export function getGridViewOptions(): BasesAllOptions[] {
     return [
         // Filtering options
         {

--- a/src/app/view/view-options.ts
+++ b/src/app/view/view-options.ts
@@ -1,4 +1,5 @@
-import type { ViewOption } from 'obsidian'
+// Obsidian v1.10.3 seemingly replaced ViewOption with BasesAllOptions
+import type { BasesAllOptions } from 'obsidian'
 import { TimeGranularity } from '../types'
 
 /**
@@ -19,7 +20,7 @@ export const DEFAULT_GRID_COLUMNS = 2
 /**
  * Get view options for Life Tracker view configuration
  */
-export function getLifeTrackerViewOptions(): ViewOption[] {
+export function getLifeTrackerViewOptions(): BasesAllOptions[] {
     return [
         // Date anchor configuration
         {


### PR DESCRIPTION
# Changes

Updated the view option type definition from `ViewOption` to `BasesAllOptions`.


# Why?

Currently, the plugin isn't working properly for me. Heatmaps weren't loading, and new chart states weren't being applied. Likely the cause is due to a change in the API since Obsidian 10.* changed how to define view options. Rebuilding with the new `BasesAllOptions` API restores the broken functionality.

I wish I could point to an exact changelog, but Obsidian's official guides still reference the outdated `ViewOption` definition, even though it no longer has a documentation page. 