### PR TITLE
fix(plugin): filter null/undefined from multi-value property parsing

### DIFF
--- a/documentation/history/2026-05-15.md
+++ b/documentation/history/2026-05-15.md
@@ -1,0 +1,30 @@
+# 2026-05-15
+
+## Fixed: phantom `#undefined` chip when frontmatter field is empty (issue #83)
+
+`parseListValue` and `parseTagsValue` in `src/utils/validation.utils.ts` blindly
+ran `Array.map(String)` on inputs. YAML deserializes `field:` (empty value) into
+`[null]`, and some frontmatter writers can leave `undefined` entries — both
+became literal `"null"` / `"undefined"` chips in the capture modal selector.
+
+### Changes
+
+- Filter `null` / `undefined` / `''` from arrays before stringifying.
+- Filter literal `'null'` / `'undefined'` strings after stringifying (defensive
+  against pre-stringified inputs from external plugins).
+- Return `[]` early for top-level `null` / `undefined`.
+- Restrict the string-split branch to `string | number | boolean`; other object
+  shapes return `[]` instead of `"[object Object]"`. Also satisfies the
+  `@typescript-eslint/no-base-to-string` rule that fires once the input type is
+  narrowed away from `unknown`.
+
+### Tests
+
+`src/utils/validation.utils.spec.ts` now covers `null`, `undefined`, `[null]`,
+`[undefined]`, `['']`, and `['null', 'undefined']` inputs for both functions.
+
+### Manual verification still needed
+
+Reproducer from the issue: a note with `my_tags_field:` (empty) in frontmatter +
+a configured `tags`/`list` property → open the capture modal and confirm no
+phantom chip is pre-selected.

--- a/src/utils/validation.utils.spec.ts
+++ b/src/utils/validation.utils.spec.ts
@@ -277,6 +277,32 @@ describe('validation.utils', () => {
         test('filters empty values', () => {
             expect(parseListValue('a, , b')).toEqual(['a', 'b'])
         })
+
+        test('returns empty array for null', () => {
+            expect(parseListValue(null)).toEqual([])
+        })
+
+        test('returns empty array for undefined', () => {
+            expect(parseListValue(undefined)).toEqual([])
+        })
+
+        test('filters null entries from arrays (YAML empty value)', () => {
+            expect(parseListValue([null])).toEqual([])
+            expect(parseListValue(['a', null, 'b'])).toEqual(['a', 'b'])
+        })
+
+        test('filters undefined entries from arrays', () => {
+            expect(parseListValue([undefined])).toEqual([])
+            expect(parseListValue(['a', undefined, 'b'])).toEqual(['a', 'b'])
+        })
+
+        test('filters empty string entries from arrays', () => {
+            expect(parseListValue(['a', '', 'b'])).toEqual(['a', 'b'])
+        })
+
+        test('filters literal "null" and "undefined" string entries', () => {
+            expect(parseListValue(['a', 'null', 'undefined', 'b'])).toEqual(['a', 'b'])
+        })
     })
 
     describe('parseTagsValue', () => {
@@ -290,6 +316,35 @@ describe('validation.utils', () => {
 
         test('returns array as-is', () => {
             expect(parseTagsValue(['#tag1', '#tag2'])).toEqual(['#tag1', '#tag2'])
+        })
+
+        test('returns empty array for null', () => {
+            expect(parseTagsValue(null)).toEqual([])
+        })
+
+        test('returns empty array for undefined', () => {
+            expect(parseTagsValue(undefined)).toEqual([])
+        })
+
+        test('filters null entries from arrays (YAML empty value)', () => {
+            expect(parseTagsValue([null])).toEqual([])
+            expect(parseTagsValue(['#tag1', null, '#tag2'])).toEqual(['#tag1', '#tag2'])
+        })
+
+        test('filters undefined entries from arrays', () => {
+            expect(parseTagsValue([undefined])).toEqual([])
+            expect(parseTagsValue(['#tag1', undefined, '#tag2'])).toEqual(['#tag1', '#tag2'])
+        })
+
+        test('filters empty string entries from arrays', () => {
+            expect(parseTagsValue(['#tag1', '', '#tag2'])).toEqual(['#tag1', '#tag2'])
+        })
+
+        test('filters literal "null" and "undefined" string entries', () => {
+            expect(parseTagsValue(['#tag1', 'null', 'undefined', '#tag2'])).toEqual([
+                '#tag1',
+                '#tag2'
+            ])
         })
     })
 

--- a/src/utils/validation.utils.ts
+++ b/src/utils/validation.utils.ts
@@ -392,26 +392,50 @@ export function validateTags(value: unknown, definition: PropertyDefinition): Va
 }
 
 /**
- * Parse a value into a list of strings
+ * Parse a value into a list of strings.
+ *
+ * YAML deserializes `field:` (empty value) into `[null]`; some plugins also insert
+ * `undefined` entries. Filter both out before/after stringification so they don't
+ * surface as literal "null"/"undefined" chips.
  */
 export function parseListValue(value: unknown): string[] {
-    if (Array.isArray(value)) {
-        return value.map(String)
+    if (value === null || value === undefined) {
+        return []
     }
-    return String(value)
-        .split(',')
-        .map((v) => v.trim())
-        .filter(Boolean)
+    if (Array.isArray(value)) {
+        return value
+            .filter((v) => v !== null && v !== undefined && v !== '')
+            .map(String)
+            .filter((v) => v !== 'null' && v !== 'undefined')
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value)
+            .split(',')
+            .map((v) => v.trim())
+            .filter(Boolean)
+    }
+    return []
 }
 
 /**
- * Parse a value into a list of tags
+ * Parse a value into a list of tags.
+ *
+ * See {@link parseListValue} for the empty-frontmatter rationale.
  */
 export function parseTagsValue(value: unknown): string[] {
-    if (Array.isArray(value)) {
-        return value.map(String)
+    if (value === null || value === undefined) {
+        return []
     }
-    return String(value)
-        .split(/[,\s]+/)
-        .filter(Boolean)
+    if (Array.isArray(value)) {
+        return value
+            .filter((v) => v !== null && v !== undefined && v !== '')
+            .map(String)
+            .filter((v) => v !== 'null' && v !== 'undefined')
+    }
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return String(value)
+            .split(/[,\s]+/)
+            .filter(Boolean)
+    }
+    return []
 }


### PR DESCRIPTION
Closes #83.

## Problem

`parseListValue` and `parseTagsValue` in `src/utils/validation.utils.ts` blindly called `Array.map(String)` on inputs. YAML deserializes an empty frontmatter field (`my_tags_field:`) into `[null]`; some frontmatter writers also insert `undefined` entries. Both became literal `"null"` / `"undefined"` chips in the capture modal selector — hence the phantom `#undefined` chip reported in the issue.

## Fix

- Filter `null` / `undefined` / `''` entries from arrays before stringifying.
- Filter literal `'null'` / `'undefined'` strings after stringifying (defensive against pre-stringified inputs from external plugins).
- Return `[]` early for top-level `null` / `undefined`.
- Restrict the string-split branch to `string | number | boolean`; other object shapes return `[]` instead of `"[object Object]"`. Also satisfies the `@typescript-eslint/no-base-to-string` rule that fires once the input type is narrowed away from `unknown`.

## Tests

`src/utils/validation.utils.spec.ts` now covers `null`, `undefined`, `[null]`, `[undefined]`, `['']`, and `['null', 'undefined']` inputs for both functions.

## Verification gates

- `bun run tsc` — clean
- `bun run lint` — clean (zero warnings)
- `bun test` — 324 / 324 pass
- `bun run build` — succeeds

## Manual verification still needed

Reproducer from the issue: a note with `my_tags_field:` (empty) in frontmatter + a configured `tags` / `list` property → open the capture modal and confirm no phantom chip is pre-selected.