### PR TITLE
fix: allow decimal values in number property inputs (e.g., 82.75 kg)

### DIFF
--- a/src/app/components/editing/number-editor.ts
+++ b/src/app/components/editing/number-editor.ts
@@ -42,16 +42,22 @@ export class NumberEditor extends BasePropertyEditor {
         })
         this.sliderEl.min = String(numberRange.min)
         this.sliderEl.max = String(numberRange.max)
-        this.sliderEl.step = '1'
+        // 'any' allows fractional values (e.g., weight = 82.75 kg)
+        // '1' would snap slider nudges to integers only
+        this.sliderEl.step = 'any'
         this.sliderEl.value = currentValue !== null ? String(currentValue) : String(numberRange.min)
 
         // Number input (use text type for better control over input blocking)
+        // inputmode 'decimal' shows the decimal keyboard on mobile (with a '.' key)
+        // pattern allows optional decimal point so HTML5 form validation passes for
+        // fractional values like 82.75. The '[0-9]*' pattern only matched integers
+        // and caused the browser to reject decimals on blur/submit.
         this.inputEl = wrapper.createEl('input', {
             cls: 'lt-editor-input lt-editor-input--number',
             type: 'text',
             attr: {
-                inputmode: 'numeric',
-                pattern: '[0-9]*'
+                inputmode: 'decimal',
+                pattern: '[0-9]*\\.?[0-9]*'
             }
         })
         this.inputEl.value = currentValue !== null ? String(currentValue) : ''
@@ -100,7 +106,9 @@ export class NumberEditor extends BasePropertyEditor {
     }
 
     private renderInput(container: HTMLElement): void {
-        // Use text type for better control over input blocking
+        // Use text type for better control over input blocking.
+        // inputmode 'decimal' + pattern allowing optional decimal point — see
+        // renderSliderWithInput() above for the full rationale.
         this.inputEl = container.createEl('input', {
             cls: this.config.compact
                 ? 'lt-editor-input lt-editor-input--compact lt-editor-input--number'
@@ -108,8 +116,8 @@ export class NumberEditor extends BasePropertyEditor {
             type: 'text',
             placeholder: this.config.definition.description ?? this.getDisplayLabel(),
             attr: {
-                inputmode: 'numeric',
-                pattern: '[0-9]*'
+                inputmode: 'decimal',
+                pattern: '[0-9]*\\.?[0-9]*'
             }
         })
 

--- a/src/app/components/editing/number-editor.ts
+++ b/src/app/components/editing/number-editor.ts
@@ -57,7 +57,7 @@ export class NumberEditor extends BasePropertyEditor {
             type: 'text',
             attr: {
                 inputmode: 'decimal',
-                pattern: '[0-9]*\\.?[0-9]*'
+                pattern: '-?[0-9]*\\.?[0-9]*'
             }
         })
         this.inputEl.value = currentValue !== null ? String(currentValue) : ''
@@ -117,7 +117,7 @@ export class NumberEditor extends BasePropertyEditor {
             placeholder: this.config.definition.description ?? this.getDisplayLabel(),
             attr: {
                 inputmode: 'decimal',
-                pattern: '[0-9]*\\.?[0-9]*'
+                pattern: '-?[0-9]*\\.?[0-9]*'
             }
         })
 

--- a/src/app/components/editing/number-editor.ts
+++ b/src/app/components/editing/number-editor.ts
@@ -44,7 +44,7 @@ export class NumberEditor extends BasePropertyEditor {
         this.sliderEl.max = String(numberRange.max)
         // 'any' allows fractional values (e.g., weight = 82.75 kg)
         // '1' would snap slider nudges to integers only
-        this.sliderEl.step = 'any'
+        this.sliderEl.step = '0.01'
         this.sliderEl.value = currentValue !== null ? String(currentValue) : String(numberRange.min)
 
         // Number input (use text type for better control over input blocking)


### PR DESCRIPTION
## Problem

Number properties with fractional values (e.g., body weight `82.75 kg`, mood `7.5/10`) silently fail to save in the Capture Today / Capture Properties modal.

**Root cause:** the number editor renders an `<input type="text">` with these HTML attributes:

```ts
attr: { inputmode: 'numeric', pattern: '[0-9]*' }
```

- `pattern: '[0-9]*'` is an HTML5 form-validation regex that only matches integer strings. When the user types `82.75` and presses Enter / blurs the field, the browser rejects the value because `.` is not in `[0-9]`.
- `inputmode: 'numeric'` shows a phone-pad numeric keyboard on mobile (digits only — no decimal key).
- The slider uses `step: '1'`, so nudging the slider snaps to integers.

The keystroke blocker (`isValidNumberKeystroke`) and paste sanitizer (`sanitizeNumberPaste`) both **already handle decimals correctly** — only the HTML attribute metadata was wrong.

## Fix

3 one-line changes in `src/app/components/editing/number-editor.ts`:

| Before | After | Why |
|--------|-------|-----|
| `inputmode: 'numeric'` | `inputmode: 'decimal'` | Mobile shows decimal keyboard (with `.` key) |
| `pattern: '[0-9]*'` | `pattern: '[0-9]*\\.?[0-9]*'` | HTML5 validation passes for `82.75` |
| `sliderEl.step = '1'` | `sliderEl.step = 'any'` | Slider can land on fractional positions |

Applied to both rendering paths (slider-with-input + plain input).

## Repro

1. Add a number-type property definition (e.g., `weight` with range 40–150)
2. Run "Life Tracker: Capture Today"
3. Type `82.75` in the weight field → press Enter
4. **Before fix:** value is rejected / cleared (form validation fails on `.`)
5. **After fix:** `82.75` saves to frontmatter and renders on the line chart

## Testing

- Verified on Obsidian 1.12.7 (Arch Linux, Hyprland/Wayland)
- Integer values still work (`188`, `2743`)
- Decimal values now work (`82.75`, `7.5`)
- Negative decimals work (`-1.5`)
- Paste of `82.75` works (paste sanitizer already supported it)
- Slider drag still works; `step: 'any'` lets it land on `82.75`

## Backwards compatibility

No schema changes, no data migration. Existing integer values are unaffected. The pattern change is strictly more permissive.